### PR TITLE
Release 0.5.5: recover Native relay routes and support Android identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # DiodeJs
 
+Native TCP relay selection now checks the allocated data socket before accepting
+a relay. An unreachable socket closes that allocation and releases its lease,
+then tries the other available relays while the application socket stays paused.
+Cancellation closes late allocations. There is no API downgrade or replay of
+application data; failures after authentication still end the stream.
+
+On 2026-09-09, the live disposable-peer benchmark through `eu1.prenet.diode.io`
+passed Native TCP twice (1 MiB upload-plus-echo, 60.32 and 73.56 Mbps, not one-way
+capacity). The OrendaService application test still failed on its automatically
+selected route: allocated data-port timeouts and a handshake timeout. A successful
+control connection or local relay test does not qualify a public Native route.
+This branch is unreleased; installed diodejs 0.5.4 does not contain this retry fix.
+
 ### Relay selection and live performance
 
 Connected relays rank by measured RTT, with recently failed probes demoted.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DiodeJs
 
+Release candidate: `0.5.5`, including Native TCP allocation retries, Android identity storage, and stale-route recovery.
+
 First-start identity creation supports Android app storage, where SELinux can
 deny hard links. The fallback uses a private directory lock and atomic rename
 of the complete, flushed key file. Concurrent starters reuse the winning identity;

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ closed after five seconds. If startup crashed before creating `keys.json`, stop
 all writers and remove only the empty `keys.json.lock` directory before retrying.
 Never delete an existing identity to resolve a connection error.
 
+If all connected routes return `not found`, tunnel opening tries at most three
+additional configured seed relays. Each trial stays available until the caller
+registers its tunnel; idle RTT pruning can then resume. Existing connection and
+RPC deadlines bound each attempt. This recovers stale destination tickets on
+clients with a small warm-relay budget. Transport selection and publisher access
+checks are preserved; application data is never replayed.
+
 Native TCP relay selection now checks the allocated data socket before accepting
 a relay. An unreachable socket closes that allocation and releases its lease,
 then tries the other available relays while the application socket stays paused.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # DiodeJs
 
+First-start identity creation supports Android app storage, where SELinux can
+deny hard links. The fallback uses a private directory lock and atomic rename
+of the complete, flushed key file. Concurrent starters reuse the winning identity;
+existing or corrupt identities are never replaced. A stale creation lock fails
+closed after five seconds. If startup crashed before creating `keys.json`, stop
+all writers and remove only the empty `keys.json.lock` directory before retrying.
+Never delete an existing identity to resolve a connection error.
+
 Native TCP relay selection now checks the allocated data socket before accepting
 a relay. An unreachable socket closes that allocation and releases its lease,
 then tries the other available relays while the application socket stays paused.

--- a/bindPort.js
+++ b/bindPort.js
@@ -448,8 +448,8 @@ class BindPort extends EventEmitter {
     return candidates;
   }
 
-  _openApiPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags = 'rw') {
-    return this._openPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags, false);
+  _openApiPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags = 'rw', options = {}) {
+    return this._openPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags, false, options);
   }
 
   _openNativePortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags = 'rw', options = {}) {
@@ -461,31 +461,34 @@ class BindPort extends EventEmitter {
     let clearedCache = false;
     let lastError = null;
 
+    const open = async connection => {
+      const rpc = this._getRpcFor(connection);
+      const relayKey = this._connectionKey(connection) || 'unknown relay';
+      const ref = await this._withTimeout(
+        () => native
+          ? rpc.portOpen2(deviceId, formattedTargetPort, flags, { timeoutMs: this.portOpenTimeoutMs })
+          : rpc.portOpen(deviceId, formattedTargetPort, flags, { timeoutMs: this.portOpenTimeoutMs }),
+        this.portOpenTimeoutMs,
+        `${native ? 'portopen2' : 'portopen'} ${formattedTargetPort} via ${relayKey}`
+      );
+      if (!(native ? Number.isInteger(ref) && ref > 0 && ref <= 65535 : ref))
+        throw new Error(`${native ? 'portopen2 returned no valid port' : 'portopen returned no ref'} via ${relayKey}`);
+      const opened = native ? { connection, rpc, physicalPort: ref } : { connection, rpc, ref };
+      if (options.prepare) Object.assign(opened, await options.prepare(opened));
+      return opened;
+    };
+
     for (let index = 0; index < candidates.length; index += 1) {
       if (options.cancelled?.()) throw new Error('Bind closed during relay selection');
       const connection = candidates[index];
-      const rpc = this._getRpcFor(connection);
       const relayKey = this._connectionKey(connection) || 'unknown relay';
 
       try {
-        const ref = await this._withTimeout(
-          () => native
-            ? rpc.portOpen2(deviceId, formattedTargetPort, flags, { timeoutMs: this.portOpenTimeoutMs })
-            : rpc.portOpen(deviceId, formattedTargetPort, flags, { timeoutMs: this.portOpenTimeoutMs }),
-          this.portOpenTimeoutMs,
-          `${native ? 'portopen2' : 'portopen'} ${formattedTargetPort} via ${relayKey}`
-        );
-        if (native ? Number.isInteger(ref) && ref > 0 && ref <= 65535 : ref) {
-          const opened = native ? { connection, rpc, physicalPort: ref } : { connection, rpc, ref };
-          // Native allocation alone does not prove the relay data port is
-          // reachable. TCP callers complete that connection before selection.
-          if (options.prepare) Object.assign(opened, await options.prepare(opened));
-          if (index > 0) {
-            logger.info(() => `Port ${formattedTargetPort} opened via fallback relay ${relayKey}`);
-          }
-          return opened;
+        const opened = await open(connection);
+        if (index > 0) {
+          logger.info(() => `Port ${formattedTargetPort} opened via fallback relay ${relayKey}`);
         }
-        lastError = new Error(`${native ? 'portopen2 returned no valid port' : 'portopen returned no ref'} via ${relayKey}`);
+        return opened;
       } catch (error) {
         lastError = error;
         if (options.cancelled?.()) throw error;
@@ -506,6 +509,10 @@ class BindPort extends EventEmitter {
       }
     }
 
+    if (String(lastError?.reason || lastError?.message).toLowerCase() === 'not found' &&
+        typeof this.connection?.withSeedRelayFallback === 'function') {
+      return this.connection.withSeedRelayFallback(candidates.map(connection => this._connectionKey(connection)), open, options);
+    }
     throw lastError || new Error('No relay connection available');
   }
 
@@ -1337,7 +1344,8 @@ class BindPort extends EventEmitter {
 
         // Legacy API relay
         try {
-          const opened = await this._openApiPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, 'rw');
+          const opened = await this._openApiPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, 'rw',
+            { cancelled: () => context.closed || clientClosed || clientSocket.destroyed });
           connection = opened.connection;
           rpc = opened.rpc;
           ref = opened.ref;

--- a/bindPort.js
+++ b/bindPort.js
@@ -452,16 +452,17 @@ class BindPort extends EventEmitter {
     return this._openPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags, false);
   }
 
-  _openNativePortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags = 'rw') {
-    return this._openPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags, true);
+  _openNativePortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags = 'rw', options = {}) {
+    return this._openPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags, true, options);
   }
 
-  async _openPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags, native) {
+  async _openPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags, native, options = {}) {
     let candidates = await this._getApiRelayCandidates(deviceId, deviceIdHex);
     let clearedCache = false;
     let lastError = null;
 
     for (let index = 0; index < candidates.length; index += 1) {
+      if (options.cancelled?.()) throw new Error('Bind closed during relay selection');
       const connection = candidates[index];
       const rpc = this._getRpcFor(connection);
       const relayKey = this._connectionKey(connection) || 'unknown relay';
@@ -475,14 +476,19 @@ class BindPort extends EventEmitter {
           `${native ? 'portopen2' : 'portopen'} ${formattedTargetPort} via ${relayKey}`
         );
         if (native ? Number.isInteger(ref) && ref > 0 && ref <= 65535 : ref) {
+          const opened = native ? { connection, rpc, physicalPort: ref } : { connection, rpc, ref };
+          // Native allocation alone does not prove the relay data port is
+          // reachable. TCP callers complete that connection before selection.
+          if (options.prepare) Object.assign(opened, await options.prepare(opened));
           if (index > 0) {
             logger.info(() => `Port ${formattedTargetPort} opened via fallback relay ${relayKey}`);
           }
-          return native ? { connection, rpc, physicalPort: ref } : { connection, rpc, ref };
+          return opened;
         }
         lastError = new Error(`${native ? 'portopen2 returned no valid port' : 'portopen returned no ref'} via ${relayKey}`);
       } catch (error) {
         lastError = error;
+        if (options.cancelled?.()) throw error;
       }
 
       logger.warn(() => `Port ${formattedTargetPort} did not open via ${relayKey}: ${lastError}`);
@@ -501,6 +507,54 @@ class BindPort extends EventEmitter {
     }
 
     throw lastError || new Error('No relay connection available');
+  }
+
+  async _connectNativeTcpRelay(opened, context) {
+    Object.assign(context, opened, { nativeCloseStarted: false });
+    this._acquireNativeLease(context);
+    let relaySocket;
+    try {
+      if (context.closed) throw new Error('Bind closed during portopen2');
+      const relayHost = opened.connection.getServerRelayHost();
+      relaySocket = net.connect({ host: relayHost, port: opened.physicalPort, allowHalfOpen: true, autoSelectFamily: false });
+      relaySocket.setNoDelay(true);
+      relaySocket.pause();
+      context.sockets.add(relaySocket);
+      // Keep asynchronous destroy errors handled after the temporary listeners
+      // are removed. Successful streams get their lifecycle handler below.
+      relaySocket.on('error', () => {});
+      await new Promise((resolve, reject) => {
+        let settled = false;
+        const finish = error => {
+          if (settled) return;
+          settled = true; clearTimeout(timer);
+          relaySocket.off('connect', connected);
+          relaySocket.off('error', finish);
+          relaySocket.off('close', closed);
+          if (error) reject(error); else resolve();
+        };
+        const connected = () => finish();
+        const closed = () => finish(new Error('Relay socket closed before connect'));
+        const timer = setTimeout(() => finish(new Error(`Relay socket connection timed out for ${relayHost}:${opened.physicalPort}`)),
+          normalizeTimerMs(this.portOpenTimeoutMs, 5000));
+        relaySocket.once('connect', connected);
+        relaySocket.once('error', finish);
+        relaySocket.once('close', closed);
+      });
+      return { relaySocket };
+    } catch (error) {
+      logger.error(() => `Native TCP relay connection failed: ${error}`);
+      // Close only this attempt. Keep the paused application socket available
+      // for another relay; no handshake or application bytes have been sent.
+      this._closeNativePort(context);
+      if (context.nativeLease) {
+        context.connection._diodeActiveNativeSessions = Math.max(0, Number(context.connection._diodeActiveNativeSessions || 0) - 1);
+        context.nativeLease = false;
+      }
+      context.sockets.delete(relaySocket); destroySocket(relaySocket);
+      context.physicalPort = null; context.connection = null; context.rpc = null;
+      throw error;
+    }
   }
 
   async _openTlsHandshakeChannel(connection, rpc, ref, context = null) {
@@ -1203,38 +1257,26 @@ class BindPort extends EventEmitter {
 
         if (useNative) {
           // Open a new native relay port on the device for this client
-          let physicalPort;
+          let physicalPort, relaySocket;
           try {
             const flags = config.flags || 'rw';
-            ({ connection, rpc, physicalPort } = await this._openNativePortWithRelayFallback(
-              deviceId, deviceIdHex, formattedTargetPort, flags
+            ({ connection, rpc, physicalPort, relaySocket } = await this._openNativePortWithRelayFallback(
+              deviceId, deviceIdHex, formattedTargetPort, flags, {
+                cancelled: () => context.closed || clientClosed || clientSocket.destroyed,
+                prepare: opened => this._connectNativeTcpRelay(opened, context),
+              }
             ));
           } catch (error) {
             logger.error(() => `Error opening portopen2 ${formattedTargetPort} on device: ${error}`);
-            clientSocket.destroy();
+            this._closeContext(context);
             return;
           }
-          context.connection = connection;
-          context.rpc = rpc;
-          context.physicalPort = physicalPort;
-          this._acquireNativeLease(context);
           if (clientClosed || context.closed || clientSocket.destroyed) {
-            this._closeNativePort(context);
+            this._closeContext(context);
             return;
           }
 
           const relayHost = connection.getServerRelayHost();
-          let relaySocket;
-          try {
-            relaySocket = net.connect({ host: relayHost, port: physicalPort, allowHalfOpen: true, autoSelectFamily: false });
-          } catch (error) {
-            logger.error(() => `Could not create native relay socket: ${error}`);
-            this._closeContext(context);
-            return;
-          }
-          relaySocket.setNoDelay(true);
-          relaySocket.pause();
-          context.sockets.add(relaySocket);
 
           let session = null;
           let bridge = null;
@@ -1248,35 +1290,6 @@ class BindPort extends EventEmitter {
           });
           relaySocket.on('close', () => { if (!bridge) cleanup(); });
 
-          try {
-            await new Promise((resolve, reject) => {
-              let settled = false;
-              const finish = (error) => {
-                if (settled) return;
-                settled = true;
-                clearTimeout(timer);
-                relaySocket.off('connect', onConnect);
-                relaySocket.off('error', onConnectError);
-                relaySocket.off('close', onConnectClose);
-                if (error) reject(error);
-                else resolve();
-              };
-              const onConnect = () => finish();
-              const onConnectError = (error) => finish(error);
-              const onConnectClose = () => finish(new Error('Relay socket closed before connect'));
-              const timer = setTimeout(
-                () => finish(new Error(`Relay socket connection timed out for ${relayHost}:${physicalPort}`)),
-                normalizeTimerMs(this.portOpenTimeoutMs, 5000)
-              );
-              relaySocket.once('connect', onConnect);
-              relaySocket.once('error', onConnectError);
-              relaySocket.once('close', onConnectClose);
-            });
-          } catch (error) {
-            logger.error(() => `Native TCP relay connection failed: ${error}`);
-            cleanup();
-            return;
-          }
           logger.info(() => `Connected to relay ${relayHost}:${physicalPort} for ${formattedTargetPort}`);
 
           if (clientClosed || context.closed || clientSocket.destroyed) {

--- a/clientManager.js
+++ b/clientManager.js
@@ -195,6 +195,7 @@ class DiodeClientManager extends EventEmitter {
     this._lastNetworkDiscoveryStats = null;
     this._lastDeviceResolutionTrace = null;
     this._closed = false;
+    this._relayTrialHosts = new Map();
     this._lifecycleGeneration = 0;
     this.fleetContract = DEFAULT_FLEET_CONTRACT;
 
@@ -1297,6 +1298,7 @@ class DiodeClientManager extends EventEmitter {
     if (!hostKey) {
       return false;
     }
+    if (this._relayTrialHosts.get(hostKey) > 0) return true;
     const score = this.relayScores.get(hostKey);
     if (score && score.discoveredFrom === 'target') {
       return true;
@@ -1362,6 +1364,39 @@ class DiodeClientManager extends EventEmitter {
       }
       this._closeManagedConnection(connection);
     }
+  }
+
+  // A fast but stale destination ticket can leave every warm relay returning
+  // "not found". Try at most three other configured seeds, retaining each
+  // connection while its tunnel is opened instead of pruning it by RTT first.
+  async withSeedRelayFallback(excludedHosts, open, options = {}) {
+    const excluded = new Set(excludedHosts);
+    const hosts = [...new Set(this.initialHosts.map(host => normalizeHostKey(host, this.defaultPort)))];
+    const generation = this._lifecycleGeneration;
+    let lastError;
+    for (const host of hosts.filter(host => host && !excluded.has(host)).slice(0, 3)) {
+      if (this._closed || generation !== this._lifecycleGeneration || options.cancelled?.())
+        throw new Error('Bind closed during seed relay selection');
+      this._relayTrialHosts.set(host, (this._relayTrialHosts.get(host) || 0) + 1);
+      try {
+        const connection = await this._probeHost(host, 'seed');
+        if (this._closed || generation !== this._lifecycleGeneration || options.cancelled?.())
+          throw new Error('Bind closed during seed relay selection');
+        return await open(connection);
+      } catch (error) {
+        lastError = error;
+      } finally {
+        // Let the caller register the accepted tunnel in its promise
+        // continuation before normal idle pruning resumes.
+        setImmediate(() => {
+          const count = (this._relayTrialHosts.get(host) || 1) - 1;
+          if (count > 0) this._relayTrialHosts.set(host, count);
+          else this._relayTrialHosts.delete(host);
+          this._pruneIdleConnections();
+        });
+      }
+    }
+    throw lastError || new Error('No additional seed relay available');
   }
 
   async _ensureConnection(hostEntry) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diodejs",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "diodejs",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diodejs",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A JavaScript client for interacting with the Diode network. It provides functionalities to bind and publish ports, send RPC commands, and handle responses.",
   "main": "index.js",
   "files": [

--- a/test/bindPort.test.js
+++ b/test/bindPort.test.js
@@ -226,6 +226,37 @@ test('API portopen tries connected relays when device relay lookup fails', async
   }]);
 });
 
+test('stale warm routes try another seed without changing the transport', async () => {
+  for (const native of [false, true]) {
+    const calls = [];
+    const bad = makeRelay('stale.relay:41046', new Error('not found'), calls);
+    bad.RPC.portOpen2 = bad.RPC.portOpen;
+    const goodRef = makeRef('12345678');
+    const good = makeRelay('cold.seed:41046', native ? 41000 : goodRef, calls);
+    good.RPC.portOpen2 = good.RPC.portOpen;
+    const manager = new FakeManager({relays:[bad],resolvedRelay:bad,nearestRelay:bad});
+    manager.withSeedRelayFallback = async (excluded, open) => {
+      assert.deepEqual(excluded, ['stale.relay:41046']);
+      return open(good);
+    };
+    const bind = new BindPort(manager, {});
+    const result = await bind._openPortWithRelayFallback(Buffer.alloc(20), '00'.repeat(20), 'tcp:8088', 'rw', native, {});
+    assert.equal(result.connection, good);
+    assert.equal(native ? result.physicalPort : result.ref, native ? 41000 : goodRef);
+    assert.deepEqual(calls.map(c=>c.hostKey), ['stale.relay:41046','cold.seed:41046']);
+    bind.dispose();
+  }
+});
+
+test('an authorization rejection never expands to additional seed relays', async () => {
+  const denied=makeRelay('denied.relay:41046',new Error('Device not whitelisted'),[]);
+  const manager=new FakeManager({relays:[denied],resolvedRelay:denied,nearestRelay:denied});
+  manager.withSeedRelayFallback=()=>assert.fail('Denied access must not expand relay discovery');
+  const bind=new BindPort(manager,{});
+  await assert.rejects(bind._openApiPortWithRelayFallback(Buffer.alloc(20),'00'.repeat(20),'tcp:8088'),/not whitelisted/);
+  bind.dispose();
+});
+
 test('multiple BindPort instances share one manager listener set', () => {
   const manager = new FakeManager({
     relays: [],

--- a/test/keyStorage.test.js
+++ b/test/keyStorage.test.js
@@ -18,16 +18,18 @@ function mode(filePath) {
   return fs.statSync(filePath).mode & 0o777;
 }
 
-function runKeyLoader(keyLocation) {
+function runKeyLoader(keyLocation, denyHardLinks = false) {
   const utilsPath = require.resolve('../utils');
   const script = [
     "const crypto=require('node:crypto')",
+    denyHardLinks ? "require('node:fs').linkSync=()=>{throw Object.assign(new Error('Android denies hard links'),{code:'EACCES'})}" : '',
     `const {loadOrGenerateKeyPair}=require(${JSON.stringify(utilsPath)})`,
     'const keyPair=loadOrGenerateKeyPair(process.argv[1])',
     "process.stdout.write(crypto.createHash('sha256').update(keyPair.prvKeyObj.prvKeyHex).digest('hex'))",
   ].join(';');
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, ['-e', script, keyLocation], {
+      windowsHide: true,
       env: { ...process.env, LOG: 'false' },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -107,23 +109,48 @@ test('failed atomic installation leaves no partial target or temporary secret', 
   const root = makeTempDir(t);
   const keyLocation = path.join(root, 'identity', 'keys.json');
   const originalLinkSync = fs.linkSync;
+  const originalRenameSync = fs.renameSync;
   fs.linkSync = () => {
-    const error = new Error('simulated atomic install failure');
+    const error = new Error('Android denies hard links');
     error.code = 'EPERM';
     throw error;
   };
+  fs.renameSync = () => { throw new Error('simulated atomic install failure'); };
 
   try {
     assert.throws(() => loadOrGenerateKeyPair(keyLocation), /atomic install failure/);
   } finally {
     fs.linkSync = originalLinkSync;
+    fs.renameSync = originalRenameSync;
   }
 
   assert.equal(fs.existsSync(keyLocation), false);
+  assert.equal(fs.existsSync(`${keyLocation}.lock`), false);
   assert.deepEqual(
     fs.readdirSync(path.dirname(keyLocation)).filter((name) => name.endsWith('.tmp')),
     []
   );
+});
+
+test('Android first-start processes converge without hard-link support', async (t) => {
+  const root = makeTempDir(t);
+  const keyLocation = path.join(root, 'identity', 'keys.json');
+  const fingerprints = await Promise.all(Array.from({length: 6}, () => runKeyLoader(keyLocation, true)));
+  assert.equal(new Set(fingerprints).size, 1);
+  assert.deepEqual(fs.readdirSync(path.dirname(keyLocation)), ['keys.json']);
+  assert.equal(fingerprints[0], crypto.createHash('sha256').update(loadOrGenerateKeyPair(keyLocation).prvKeyObj.prvKeyHex).digest('hex'));
+  if (process.platform !== 'win32') assert.equal(mode(keyLocation), 0o600);
+});
+
+test('an abandoned creation lock fails closed without removing another writer lock', (t) => {
+  const root = makeTempDir(t);
+  const keyLocation = path.join(root, 'keys.json');
+  fs.mkdirSync(`${keyLocation}.lock`);
+  const originalLinkSync = fs.linkSync;
+  fs.linkSync = () => { throw Object.assign(new Error('Android denies hard links'), {code:'EACCES'}); };
+  try { assert.throws(() => loadOrGenerateKeyPair(keyLocation), {code:'EBUSY'}); }
+  finally { fs.linkSync = originalLinkSync; }
+  assert.deepEqual(fs.readdirSync(root), ['keys.json.lock']);
 });
 
 test('a corrupt existing identity is never silently replaced', (t) => {

--- a/test/nativeRelaySelection.test.js
+++ b/test/nativeRelaySelection.test.js
@@ -4,6 +4,67 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 const BindPort = require('../bindPort');
+const net = require('node:net');
+
+test('unreachable allocated TCP port retries another relay and releases the failed lease', async () => {
+  const original = net.connect;
+  const sockets = [], closedPorts = [], allocations = [];
+  const relay = name => ({ _managerHostKey: name, socket: { destroyed: false }, getServerRelayHost: () => name,
+    RPC: { portOpen2: async () => { allocations.push(name); return 42001; },
+      portClose2: async port => closedPorts.push([name, port]),
+      portOpen: () => assert.fail('No API downgrade') } });
+  const bad = relay('unreachable'), good = relay('reachable');
+  const manager = Object.assign(new EventEmitter(), { getConnectionForDevice: async () => bad,
+    getNearestConnection: () => good, getConnections: () => [bad, good] });
+  const bind = new BindPort(manager, {});
+  bind.portOpenTimeoutMs = 20;
+  const context = bind._trackContext({}, 0, { sockets: new Set() });
+  net.connect = options => {
+    const socket = Object.assign(new EventEmitter(), { setNoDelay() {}, pause() { this.paused = true; },
+      destroy() { this.destroyed = true; this.emit('close'); } });
+    sockets.push(socket);
+    if (options.host === 'reachable') queueMicrotask(() => socket.emit('connect'));
+    return socket;
+  };
+  try {
+    const opened = await bind._openNativePortWithRelayFallback(Buffer.alloc(20), '00'.repeat(20), 'tcp:42', 'rw', {
+      cancelled: () => context.closed, prepare: value => bind._connectNativeTcpRelay(value, context),
+    });
+    assert.equal(opened.connection, good);
+    assert.deepEqual(allocations, ['unreachable', 'reachable']);
+    assert.deepEqual(closedPorts, [['unreachable', 42001]]);
+    assert.equal(bad._diodeActiveNativeSessions, 0);
+    assert.equal(good._diodeActiveNativeSessions, 1);
+    assert.equal(sockets[0].destroyed, true);
+    assert.equal(sockets[1].paused, true, 'data waits for authenticated handshake');
+    assert.equal(context.sockets.size, 1);
+  } finally { bind._closeContext(context); bind.dispose(); net.connect = original; }
+  assert.equal(good._diodeActiveNativeSessions, 0);
+  assert.deepEqual(closedPorts, [['unreachable', 42001], ['reachable', 42001]]);
+});
+
+test('cancellation during native allocation closes the late port without selecting another relay', async () => {
+  let resolve, allocations = 0, closes = 0;
+  const relay = { _managerHostKey: 'late', socket: { destroyed: false }, RPC: {
+    portOpen2: () => { allocations++; return new Promise(r => { resolve = r; }); },
+    portClose2: async () => { closes++; },
+  } };
+  const manager = Object.assign(new EventEmitter(), { getConnectionForDevice: async () => relay,
+    getNearestConnection: () => relay, getConnections: () => [relay] });
+  const bind = new BindPort(manager, {});
+  const context = bind._trackContext({}, 0, { sockets: new Set() });
+  try {
+    const pending = bind._openNativePortWithRelayFallback(Buffer.alloc(20), '00'.repeat(20), 'tcp:42', 'rw', {
+      cancelled: () => context.closed, prepare: value => bind._connectNativeTcpRelay(value, context),
+    });
+    while (!resolve) await new Promise(r => setImmediate(r));
+    bind._closeContext(context); resolve(42001);
+    await assert.rejects(pending, /closed during portopen2/);
+    assert.equal(allocations, 1); assert.equal(closes, 1);
+    assert.equal(relay._diodeActiveNativeSessions || 0, 0);
+    assert.equal(context.sockets.size, 0);
+  } finally { bind.dispose(); }
+});
 
 test('native portopen retries another relay without downgrading or sending application data', async () => {
   const calls = [];

--- a/test/seedRelayFallback.test.js
+++ b/test/seedRelayFallback.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { setImmediate: nextTurn } = require('node:timers/promises');
+const DiodeClientManager = require('../clientManager');
+
+function manager() {
+  return new DiodeClientManager({hosts:['warm.test:1','first.test:1','second.test:1','third.test:1','fourth.test:1'],relaySelection:{scoreCachePath:null}});
+}
+
+test('seed trial survives idle pruning until the caller registers its tunnel', async () => {
+  const m=manager();
+  const pruned=[];
+  m._pruneIdleConnections=()=>{for(const host of ['first.test:1','warm.test:1'])if(!m._isProtectedHost(host))pruned.push(host);};
+  m._probeHost=async host=>{m._pruneIdleConnections();assert.ok(m._isProtectedHost(host));return {_managerHostKey:host};};
+  const result=await m.withSeedRelayFallback(['warm.test:1'],async connection=>({connection}));
+  assert.equal(result.connection._managerHostKey,'first.test:1');
+  assert.ok(m._isProtectedHost('first.test:1'),'Promise continuation still owns the lease');
+  assert.equal(pruned.includes('first.test:1'),false);
+  await nextTurn();
+  assert.equal(m._isProtectedHost('first.test:1'),false);
+  assert.ok(pruned.includes('first.test:1'));
+  m.close();
+});
+
+test('seed discovery is bounded and releases failed connection trials', async () => {
+  const m=manager(),attempts=[];
+  m._probeHost=async host=>{attempts.push(host);throw new Error('unreachable seed');};
+  await assert.rejects(m.withSeedRelayFallback(['warm.test:1'],()=>assert.fail('Cannot open a failed seed')),/unreachable seed/);
+  assert.deepEqual(attempts,['first.test:1','second.test:1','third.test:1']);
+  await nextTurn();assert.equal(m._relayTrialHosts.size,0);m.close();
+});
+
+test('cancellation during seed connect prevents an application port from opening', async () => {
+  const m=manager();let cancelled=false;
+  m._probeHost=async()=>{cancelled=true;return {};};
+  await assert.rejects(m.withSeedRelayFallback(['warm.test:1'],()=>assert.fail('Cancelled bind opened a port'),{cancelled:()=>cancelled}),/Bind closed/);
+  await nextTurn();assert.equal(m._relayTrialHosts.size,0);m.close();
+});

--- a/utils.js
+++ b/utils.js
@@ -188,7 +188,7 @@ function loadOrGenerateKeyPair(keyLocation) {
       temporaryFd = null;
 
       try {
-        fs.linkSync(temporaryPath, keyLocation);
+        installKeyFile(temporaryPath, keyLocation);
       } catch (error) {
         if (error && error.code === 'EEXIST') {
           return loadKeyPairFile(keyLocation);
@@ -210,6 +210,50 @@ function loadOrGenerateKeyPair(keyLocation) {
   } catch (error) {
     logger.error(() => `Error loading or generating key pair: ${error}`);
     throw error;
+  }
+}
+
+function installKeyFile(temporaryPath, keyLocation) {
+  try {
+    fs.linkSync(temporaryPath, keyLocation);
+    return;
+  } catch (error) {
+    // Android app storage rejects hard links under SELinux. Keep the same
+    // complete-file, single-writer guarantee using mkdir and rename there.
+    if (!['EACCES', 'EPERM', 'ENOTSUP', 'EOPNOTSUPP', 'ENOSYS'].includes(error?.code)) throw error;
+  }
+  const lockPath = `${keyLocation}.lock`;
+  const deadline = Date.now() + 5000;
+  const wait = new Int32Array(new SharedArrayBuffer(4));
+  while (true) {
+    if (fs.existsSync(keyLocation)) {
+      const exists = new Error('Diode identity already exists');
+      exists.code = 'EEXIST';
+      throw exists;
+    }
+    try {
+      fs.mkdirSync(lockPath, { mode: 0o700 });
+      break;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+      if (Date.now() >= deadline) {
+        const busy = new Error('Diode identity creation is locked; existing identity was not changed');
+        busy.code = 'EBUSY';
+        throw busy;
+      }
+      Atomics.wait(wait, 0, 0, 20);
+    }
+  }
+  try {
+    // Another starter can finish between the first read and acquiring the lock.
+    if (fs.existsSync(keyLocation)) {
+      const exists = new Error('Diode identity already exists');
+      exists.code = 'EEXIST';
+      throw exists;
+    }
+    fs.renameSync(temporaryPath, keyLocation);
+  } finally {
+    fs.rmdirSync(lockPath);
   }
 }
 


### PR DESCRIPTION
Native TCP allocations can fail on one relay even when another route is available, and Android app storage can reject hard links during first-start identity creation. This change retries failed Native allocations, searches a bounded set of configured seed relays for stale routes, and writes new Android identities atomically while preserving existing keys.

Prepares diodejs 0.5.5. Transport selection, publisher authorization, cancellation cleanup, and the rule against replaying application data remain intact. Service and Connect mobile consume an integrity-pinned archive from c2813203aee76cc5b3a6b9d42aef8204d324c0c9, so their builds do not depend on publishing npm first.

Validation: complete Node test suite passed, including Native allocation retries, stale seed-route recovery, identity concurrency, and Android hard-link fallback. Existing Android viewer qualification is recorded in the Connect documentation.

Commits use [skip ci] as requested. No workflow, npm publish, tag, deployment, or merge was triggered.