### PR TITLE
Avoid stale relay lookups blocking config and app connections (0.5.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # DiodeJs
 
-Release candidate: `0.5.5`, including Native TCP allocation retries, Android identity storage, and stale-route recovery.
+Release candidate: `0.5.6`, fixing config/app connections delayed by stale device tickets.
+
+When a device lookup is still dialing a relay after 250 ms, bind opening tries
+ready relays and then the existing bounded seed fallback. The lookup continues
+within its original deadline and remains available for destinations reachable
+only through a cold, non-seed relay. Cancellation prevents late tunnel opens.
+This applies to both API and Native transport without changing application data
+or authorization. A live config read that previously took 21.7 seconds completed
+in 2.2–3.0 seconds with the original seven-second Service deadline.
 
 First-start identity creation supports Android app storage, where SELinux can
 deny hard links. The fallback uses a private directory lock and atomic rename

--- a/bindPort.js
+++ b/bindPort.js
@@ -174,6 +174,10 @@ class BindPort extends EventEmitter {
       process.env.DIODE_RELAY_RESOLVE_TIMEOUT_MS,
       normalizeTimerMs(Math.max(this.portOpenTimeoutMs, targetConnectMs + this.portOpenTimeoutMs), 15000)
     );
+    // A stale device ticket must not hold ready relay routes behind a cold
+    // target handshake (normally allowed ten seconds). Keep that lookup alive
+    // for direct-only destinations while trying already connected relays.
+    this.relayLookupGraceMs = 250;
     this.nativeQueueLimitBytes = parseInt(process.env.DIODE_NATIVE_QUEUE_LIMIT_BYTES, 10) || MAX_SOCKET_QUEUE_BYTES;
     this.udpSessionIdleTimeoutMs = normalizeTimerMs(process.env.DIODE_UDP_SESSION_IDLE_TIMEOUT_MS, 300000);
     this._activeContexts = new Set();
@@ -408,7 +412,7 @@ class BindPort extends EventEmitter {
     cache.delete(`0x${normalized}`);
   }
 
-  async _getApiRelayCandidates(deviceId, deviceIdHex) {
+  async _getApiRelayCandidates(deviceId, deviceIdHex, onDeferred = null) {
     const candidates = [];
     const seen = new Set();
     const push = (connection) => {
@@ -423,14 +427,32 @@ class BindPort extends EventEmitter {
       candidates.push(connection);
     };
 
-    try {
-      push(await this._withTimeout(
+    const ready = typeof this.connection?.getConnections === 'function'
+      ? this.connection.getConnections().filter(connection => this._isUsableConnection(connection))
+      : [];
+    const resolution = this._withTimeout(
         () => this._resolveConnectionForDevice(deviceId),
         this.relayResolveTimeoutMs,
         `Relay resolution for ${deviceIdHex}`
-      ));
-    } catch (error) {
+    ).catch(error => {
       logger.warn(() => `Error resolving relay for device ${deviceIdHex}: ${error}`);
+      return null;
+    });
+    if (ready.length > 0 && onDeferred) {
+      const deferred = Symbol('relay lookup pending');
+      let timer;
+      try {
+        const resolved = await Promise.race([
+          resolution,
+          new Promise(resolve => { timer = setTimeout(() => resolve(deferred), this.relayLookupGraceMs); }),
+        ]);
+        if (resolved === deferred) onDeferred(resolution);
+        else push(resolved);
+      } finally {
+        clearTimeout(timer);
+      }
+    } else {
+      push(await resolution);
     }
 
     if (typeof (this.connection && this.connection.getNearestConnection) === 'function') {
@@ -457,7 +479,9 @@ class BindPort extends EventEmitter {
   }
 
   async _openPortWithRelayFallback(deviceId, deviceIdHex, formattedTargetPort, flags, native, options = {}) {
-    let candidates = await this._getApiRelayCandidates(deviceId, deviceIdHex);
+    const deferredLookups = [];
+    const onDeferred = resolution => deferredLookups.push(resolution);
+    let candidates = await this._getApiRelayCandidates(deviceId, deviceIdHex, onDeferred);
     let clearedCache = false;
     let lastError = null;
 
@@ -498,7 +522,7 @@ class BindPort extends EventEmitter {
       if (!clearedCache) {
         clearedCache = true;
         this._clearDeviceRelayCache(deviceIdHex);
-        const refreshed = await this._getApiRelayCandidates(deviceId, deviceIdHex);
+        const refreshed = await this._getApiRelayCandidates(deviceId, deviceIdHex, onDeferred);
         for (const candidate of refreshed) {
           const key = this._connectionKey(candidate) || String(candidates.length);
           const exists = candidates.some((existing) => (this._connectionKey(existing) || '') === key);
@@ -511,7 +535,22 @@ class BindPort extends EventEmitter {
 
     if (String(lastError?.reason || lastError?.message).toLowerCase() === 'not found' &&
         typeof this.connection?.withSeedRelayFallback === 'function') {
-      return this.connection.withSeedRelayFallback(candidates.map(connection => this._connectionKey(connection)), open, options);
+      try {
+        return await this.connection.withSeedRelayFallback(candidates.map(connection => this._connectionKey(connection)), open, options);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    // Preserve cold, non-seed destinations when no ready/seed route succeeded.
+    // A deferred lookup discovers a relay only; it never opens a second tunnel
+    // after this operation has already returned or been cancelled.
+    for (const resolution of deferredLookups) {
+      const connection = await resolution;
+      if (options.cancelled?.()) throw new Error('Bind closed during relay selection');
+      if (!this._isUsableConnection(connection) || candidates.some(candidate => this._connectionKey(candidate) === this._connectionKey(connection))) continue;
+      candidates.push(connection);
+      try { return await open(connection); }
+      catch (error) { lastError = error; }
     }
     throw lastError || new Error('No relay connection available');
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diodejs",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "diodejs",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diodejs",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A JavaScript client for interacting with the Diode network. It provides functionalities to bind and publish ports, send RPC commands, and handle responses.",
   "main": "index.js",
   "files": [

--- a/test/bindPort.test.js
+++ b/test/bindPort.test.js
@@ -248,6 +248,73 @@ test('stale warm routes try another seed without changing the transport', async 
   }
 });
 
+test('a pending stale ticket lookup does not delay ready relay routes in API or Native', async () => {
+  for (const native of [false, true]) {
+    const calls = [];
+    const pending = deferred();
+    const bad = makeRelay('stale.relay:41046', new Error('not found'), calls);
+    const good = makeRelay('ready.relay:41046', native ? 41000 : makeRef('aabb'), calls);
+    bad.RPC.portOpen2 = bad.RPC.portOpen;
+    good.RPC.portOpen2 = good.RPC.portOpen;
+    const manager = new FakeManager({ relays: [bad, good], nearestRelay: bad });
+    manager.getConnectionForDevice = () => pending.promise;
+    const bind = new BindPort(manager, {});
+    bind.relayLookupGraceMs = 5;
+    try {
+      const result = await bind._openPortWithRelayFallback(Buffer.alloc(20), '00'.repeat(20), 'tcp:1454', 'rw', native);
+      assert.equal(result.connection, good, 'ready route succeeds before the stale lookup resolves');
+      pending.resolve(bad);
+      await new Promise(resolve => setImmediate(resolve));
+      assert.deepEqual(calls.map(call => call.hostKey), ['stale.relay:41046', 'ready.relay:41046']);
+    } finally {
+      pending.resolve(null);
+      bind.dispose();
+    }
+  }
+});
+
+test('cold non-seed relay is retained after ready and seed routes fail', async () => {
+  const calls = [];
+  const pending = deferred();
+  const bad = makeRelay('ready.relay:41046', new Error('not found'), calls);
+  const direct = makeRelay('direct.relay:41046', makeRef('ccdd'), calls);
+  const manager = new FakeManager({ relays: [bad], nearestRelay: bad });
+  manager.getConnectionForDevice = () => pending.promise;
+  manager.withSeedRelayFallback = async () => {
+    pending.resolve(direct);
+    throw new Error('not found');
+  };
+  const bind = new BindPort(manager, {});
+  bind.relayLookupGraceMs = 5;
+  try {
+    const result = await bind._openApiPortWithRelayFallback(Buffer.alloc(20), '00'.repeat(20), 'tls:1454');
+    assert.equal(result.connection, direct);
+    assert.deepEqual(calls.map(call => call.hostKey), ['ready.relay:41046', 'direct.relay:41046']);
+  } finally { pending.resolve(null); bind.dispose(); }
+});
+
+test('cancellation never opens a late resolved direct relay', async () => {
+  const calls = [];
+  const pending = deferred();
+  const bad = makeRelay('ready.relay:41046', new Error('not found'), calls);
+  const direct = makeRelay('direct.relay:41046', makeRef('eeff'), calls);
+  const manager = new FakeManager({ relays: [bad], nearestRelay: bad });
+  manager.getConnectionForDevice = () => pending.promise;
+  let cancelled = false;
+  manager.withSeedRelayFallback = async () => {
+    cancelled = true;
+    pending.resolve(direct);
+    throw new Error('Bind closed');
+  };
+  const bind = new BindPort(manager, {});
+  bind.relayLookupGraceMs = 5;
+  try {
+    await assert.rejects(bind._openApiPortWithRelayFallback(Buffer.alloc(20), '00'.repeat(20), 'tls:1454', 'rw',
+      { cancelled: () => cancelled }), /Bind closed/);
+    assert.deepEqual(calls.map(call => call.hostKey), ['ready.relay:41046']);
+  } finally { pending.resolve(null); bind.dispose(); }
+});
+
 test('an authorization rejection never expands to additional seed relays', async () => {
   const denied=makeRelay('denied.relay:41046',new Error('Device not whitelisted'),[]);
   const manager=new FakeManager({relays:[denied],resolvedRelay:denied,nearestRelay:denied});


### PR DESCRIPTION
A stale device ticket could spend ten seconds dialing an unavailable relay before trying any ready routes, exceeding Service's seven-second HTTP deadline on every retry. Give preferred-route lookup a 250 ms grace period, then try ready/configured-seed routes while retaining bounded late discovery for cold non-seed destinations. Cancellation prevents late tunnel opens; API/Native choice and publisher authorization are preserved.

Live config reads against the unchanged server improved from 21.7 seconds to 2.2-3.0 seconds without increasing Service's timeout. Validation: all 258 Node 20 tests; 45 Node 18 tests with JIT/WebAssembly and native addons disabled, including real TLS/TCP transfers. Release candidate 0.5.6; Service and mobile vendor this exact source archive.